### PR TITLE
Fix the linking problems between django and postgres containers

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -35,6 +35,18 @@ EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',
                     default='django.core.mail.backends.console.EmailBackend')
 
 
+# Database
+# ------------------------------------------------------------------------------
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'warp',
+        'USER': 'warp',
+        'HOST': 'postgres',
+        'PORT': 5432,
+    }
+}
+
 # CACHING
 # ------------------------------------------------------------------------------
 CACHES = {

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,6 +12,8 @@ services:
       - postgres_backup_dev:/backups
     environment:
       - POSTGRES_USER=warp
+    ports:
+      - "5432:5432"
 
   django:
     build:
@@ -23,6 +25,8 @@ services:
     environment:
       - POSTGRES_USER=warp
       - USE_DOCKER=yes
+    links:
+      - postgres:postgres
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
The test runner of django was trying to run tests with local hosted database. But our `django` server and `postgres` server are in separated containers each, so`django` container could not connect postgres database was in other container on previous settings.

So, I've added the link configs on `docker-compose-dev` and `settings/local.py`.