### PR TITLE
Fix like feature when user is authenticated

### DIFF
--- a/presentation/views.py
+++ b/presentation/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 from django.http import HttpResponse
@@ -86,6 +87,7 @@ class PresentationDelete(AuthorRequiredMixin, LoginRequiredMixin, DeleteView):
     success_url = reverse_lazy("presentation:list")
 
 
+@login_required
 def like_presentation(request, pk):
     if request.method == 'PUT':
         presentation = Presentation.objects.get(pk=pk)

--- a/warp/static/js/detail/index.js
+++ b/warp/static/js/detail/index.js
@@ -93,23 +93,3 @@ $(() => {
   });
 });
 
-
-const likePresentation = (pk) => {
-    $.ajax({
-        method: "PUT",
-        url: "/like/" + pk
-    }).done(function (data) {
-        const likeCount = Number($('#likeCount').text());
-        const likeBtn = $('#likeBtn');
-        if(data === 'True') {
-            $('#likeCount').text(likeCount + 1);
-            likeBtn.text('Unlike');
-        }
-        else {
-            $('#likeCount').text(likeCount - 1);
-            likeBtn.text('Like');
-        }
-    }).fail(function () {
-
-    })
-};

--- a/warp/templates/presentation/presentation_detail.html
+++ b/warp/templates/presentation/presentation_detail.html
@@ -86,7 +86,7 @@
     };
   {% else %}
     const showPopup = () => {
-      if(confirm('Like 는 로그인 해야 가능합니다. 로그인 페이지로 이동하시겠습니까?')) {
+      if(confirm('Like must be logged in. Go to sign-in page?')) {
         location.replace('{% url 'account_login' %}?next=/detail/{{ presentation.id }}');
       }
     };

--- a/warp/templates/presentation/presentation_detail.html
+++ b/warp/templates/presentation/presentation_detail.html
@@ -37,9 +37,10 @@
           </div>
 
           <div>
-                <button id="likeBtn" class="button primary" onclick="likePresentation({{ presentation.pk }})">
-                    {% if is_user_liked %}Unlike{% else %}Like{% endif %}
-                </button>
+            <button id="likeBtn" class="button primary"
+                    onclick="{% if user.is_authenticated %}likePresentation({{ presentation.pk }}){% else %}showPopup(){% endif %}">
+                {% if is_user_liked %}Unlike{% else %}Like{% endif %}
+            </button>
             {% if presentation.author == request.user %}
               <a class="button primary" href="{% url "presentation:update" presentation.pk %}">Update</a>
             {% endif %}
@@ -63,4 +64,32 @@
   <script type="text/javascript" src="{% static 'dist/js/mdElemsToHtmlElems.min.js' %}"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/screenfull.js/3.2.0/screenfull.min.js"></script>
   <script type="text/javascript" src="{% static 'dist/js/detail/index.min.js' %}"></script>
+  <script>
+  {% if user.is_authenticated %}
+    const likePresentation = (pk) => {
+      $.ajax({
+        method: "PUT",
+        url: "/like/" + pk
+      }).done(function (data) {
+        const likeCount = Number($('#likeCount').text());
+        const likeBtn = $('#likeBtn');
+        if(data === 'True') {
+          $('#likeCount').text(likeCount + 1);
+          likeBtn.text('Unlike');
+        }
+        else {
+          $('#likeCount').text(likeCount - 1);
+          likeBtn.text('Like');
+        }
+      }).fail(function () {
+      })
+    };
+  {% else %}
+    const showPopup = () => {
+      if(confirm('Like 는 로그인 해야 가능합니다. 로그인 페이지로 이동하시겠습니까?')) {
+        location.replace('{% url 'account_login' %}?next=/detail/{{ presentation.id }}');
+      }
+    };
+  {% endif %}
+  </script>
 {% endblock %}


### PR DESCRIPTION
I fixed like feature to using `user.is_authenticated`.
User can see confirm popup below if user clicked like and isn't authenticated.

<img width="494" alt="2017-07-01 1 40 19" src="https://user-images.githubusercontent.com/12431127/27759126-e24174f4-5e62-11e7-86fa-039e574a24ef.png">

User go to login page if user clicked.
And then user logged in, redirect to detail page using `next` parameter.